### PR TITLE
Dont error on empty requirements

### DIFF
--- a/app/lambdas/launch_requirement_job_py/launch_requirement_job.py
+++ b/app/lambdas/launch_requirement_job_py/launch_requirement_job.py
@@ -63,9 +63,8 @@ def handler(event, context):
     if check_fastq_job(fastq_id, "READ_COUNT") and requirement_type == "hasReadCountInformation":
         return run_fastq_job(fastq_obj, "READ_COUNT")
 
-    raise ValueError("Incorrect requirement type or fastqId not found.")
-
-
+    # If we reach here, we have no job to run
+    return None
 
 # if __name__ == "__main__":
 #     import json


### PR DESCRIPTION
We may return none if a job is already running for that particular job type