### PR TITLE
Supports context-aware active readset checks

### DIFF
--- a/app/event-schemas/fastq-sync-request-list.schema.json
+++ b/app/event-schemas/fastq-sync-request-list.schema.json
@@ -31,7 +31,18 @@
               "type": "object",
               "properties": {
                 "hasActiveReadSet": {
-                  "type": "boolean"
+                  "oneOf": [
+                    { "type": "boolean" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "bucket": { "type": "string", "minLength": 1, "maxLength": 63 },
+                        "prefix": { "type": "string", "minLength": 1, "maxLength": 1024 }
+                      },
+                      "required": ["bucket", "prefix"],
+                      "additionalProperties": false
+                    }
+                  ]
                 },
                 "hasQc": {
                   "type": "boolean"

--- a/app/lambdas/check_fastq_id_list_against_requirements_py/check_fastq_id_list_against_requirements.py
+++ b/app/lambdas/check_fastq_id_list_against_requirements_py/check_fastq_id_list_against_requirements.py
@@ -5,21 +5,27 @@ Check fastq id list against the requirements
 
 Takes in the inputs:
   * fastqIdList: list of fastq ids
-  * requirements: list of requirements to check against
+  * requirements: dict of requirement names to boolean or context object values
   * isUnarchivingAllowed: boolean indicating if unarchiving is allowed
 
 And outputs the following:
 
 * hasAllRequirements: boolean
+* fastqIdListWithMissingRequirements: list of fastq ids that are missing requirements
 
 """
-from typing import List
 
+# Standard imports
+from typing import Dict, List, Optional, Union, cast
 from requests import HTTPError
 
+# Layer imports
 from orcabus_api_tools.fastq import get_fastq
-from fastq_sync_tools import check_fastq_list_against_requirements_list
-from fastq_sync_tools.utils.globals import REQUIREMENT
+from fastq_sync_tools import (
+    check_fastq_list_against_requirements_list,
+    validate_has_active_readset_input,
+    REQUIREMENT,
+)
 
 
 def handler(event, context):
@@ -30,8 +36,36 @@ def handler(event, context):
     :return:
     """
     fastq_id_list: List[str] = event.get("fastqIdList", [])
-    requirements: List[REQUIREMENT] = event.get("requirements", [])
+    requirements_dict: Dict[REQUIREMENT, Union[bool, Dict[str, str]]] = event.get("requirements", {})
     is_unarchiving_allowed: bool = event.get("isUnarchivingAllowed", False)
+
+    # Parse requirements dict into a List[REQUIREMENT] and extract context if present
+    requirements: List[REQUIREMENT] = []
+    has_active_readset_context: Optional[Dict[str, str]] = None
+
+    for req_name, req_value in requirements_dict.items():
+        if req_name == "hasActiveReadSet":
+            # Validate and parse hasActiveReadSet value
+            try:
+                is_context_aware, bucket, prefix = validate_has_active_readset_input(req_value)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid hasActiveReadSet requirement value: {e}"
+                ) from e
+
+            # Include hasActiveReadSet in the requirements list
+            requirements.append("hasActiveReadSet")
+
+            # If context-aware, extract the context object
+            if is_context_aware:
+                has_active_readset_context = {
+                    "bucket": cast(str, bucket),
+                    "prefix": cast(str, prefix),
+                }
+        else:
+            # For other requirements, include if value is truthy
+            if req_value:
+                requirements.append(req_name)
 
     # Get fastqs
     try:
@@ -46,10 +80,12 @@ def handler(event, context):
             "hasAllRequirements": False,
         }
 
+    # Check requirements for the full list — ContextNotEligibleError propagates
     satisfied_requirements, unsatisfied_requirements = check_fastq_list_against_requirements_list(
         fastq_list=fastq_obj_list,
         requirements=requirements,
-        is_unarchiving_allowed=is_unarchiving_allowed
+        is_unarchiving_allowed=is_unarchiving_allowed,
+        has_active_readset_context=has_active_readset_context,
     )
 
     fastq_id_list_with_missing_requirements = []
@@ -59,7 +95,8 @@ def handler(event, context):
             satisfied_requirements_iter, unsatisfied_requirements_iter = check_fastq_list_against_requirements_list(
                 fastq_list=[fastq_obj_iter],
                 requirements=requirements,
-                is_unarchiving_allowed=is_unarchiving_allowed
+                is_unarchiving_allowed=is_unarchiving_allowed,
+                has_active_readset_context=has_active_readset_context,
             )
             if len(unsatisfied_requirements_iter) > 0:
                 fastq_id_list_with_missing_requirements.append(fastq_obj_iter['id'])

--- a/app/lambdas/check_fastq_id_list_against_requirements_py/check_fastq_id_list_against_requirements.py
+++ b/app/lambdas/check_fastq_id_list_against_requirements_py/check_fastq_id_list_against_requirements.py
@@ -36,15 +36,30 @@ def handler(event, context):
     :return:
     """
     fastq_id_list: List[str] = event.get("fastqIdList", [])
-    requirements_dict: Dict[REQUIREMENT, Union[bool, Dict[str, str]]] = event.get("requirements", {})
+    requirements: Union[List[REQUIREMENT], Dict[REQUIREMENT, Union[bool, Dict[str, str]]]] = event.get("requirements", None)
     is_unarchiving_allowed: bool = event.get("isUnarchivingAllowed", False)
 
+    # Requirements is a required field
+    if requirements is None:
+        raise ValueError("requirements is required")
+
+    # Check if requirements is a list, and turn it into a dict of objects if so
+    if isinstance(requirements, list):
+        requirements: Dict[REQUIREMENT, bool] = dict(map(
+            lambda req: (req, True),
+            requirements
+        ))
+
     # Parse requirements dict into a List[REQUIREMENT] and extract context if present
-    requirements: List[REQUIREMENT] = []
+    requirements_list: List[REQUIREMENT] = []
     has_active_readset_context: Optional[Dict[str, str]] = None
 
-    for req_name, req_value in requirements_dict.items():
+    for req_name, req_value in requirements.items():
         if req_name == "hasActiveReadSet":
+            # Include only when enabled (True or context object)
+            if isinstance(req_value, bool) and not req_value:
+                continue
+
             # Validate and parse hasActiveReadSet value
             try:
                 is_context_aware, bucket, prefix = validate_has_active_readset_input(req_value)
@@ -54,7 +69,7 @@ def handler(event, context):
                 ) from e
 
             # Include hasActiveReadSet in the requirements list
-            requirements.append("hasActiveReadSet")
+            requirements_list.append("hasActiveReadSet")
 
             # If context-aware, extract the context object
             if is_context_aware:
@@ -65,7 +80,7 @@ def handler(event, context):
         else:
             # For other requirements, include if value is truthy
             if req_value:
-                requirements.append(req_name)
+                requirements_list.append(cast(REQUIREMENT, req_name))
 
     # Get fastqs
     try:
@@ -83,7 +98,7 @@ def handler(event, context):
     # Check requirements for the full list — ContextNotEligibleError propagates
     satisfied_requirements, unsatisfied_requirements = check_fastq_list_against_requirements_list(
         fastq_list=fastq_obj_list,
-        requirements=requirements,
+        requirements=requirements_list,
         is_unarchiving_allowed=is_unarchiving_allowed,
         has_active_readset_context=has_active_readset_context,
     )
@@ -94,7 +109,7 @@ def handler(event, context):
         for fastq_obj_iter in fastq_obj_list:
             satisfied_requirements_iter, unsatisfied_requirements_iter = check_fastq_list_against_requirements_list(
                 fastq_list=[fastq_obj_iter],
-                requirements=requirements,
+                requirements=requirements_list,
                 is_unarchiving_allowed=is_unarchiving_allowed,
                 has_active_readset_context=has_active_readset_context,
             )

--- a/app/lambdas/get_fastq_and_remaining_requirements_py/get_fastq_and_remaining_requirements.py
+++ b/app/lambdas/get_fastq_and_remaining_requirements_py/get_fastq_and_remaining_requirements.py
@@ -6,6 +6,7 @@ Get the fastq list row and requirements for a given fastq id
 Inputs:
   * fastqId
   * requirements
+  * hasActiveReadSetContext (optional)
 
 Outputs:
 * fastqObj
@@ -15,13 +16,17 @@ Outputs:
 """
 
 # Standard imports
-from typing import List
+from typing import Dict, List, Optional
 
 # Orcabus imports
 from orcabus_api_tools.fastq import get_fastq
 
 # Local layer imports
-from fastq_sync_tools import check_fastq_against_requirements_list, REQUIREMENT
+from fastq_sync_tools import (
+    check_fastq_against_requirements_list,
+    ContextNotEligibleError,
+    REQUIREMENT,
+)
 
 
 def handler(event, context):
@@ -31,19 +36,24 @@ def handler(event, context):
     fastq_id: str = event.get("fastqId")
     requirements: List[REQUIREMENT] = event.get("requirements", [])
     is_unarchiving_allowed: bool = event.get("isUnarchivingAllowed", False)
+    has_active_readset_context: Optional[Dict[str, str]] = event.get("hasActiveReadSetContext", None)
 
     if not fastq_id:
         raise ValueError("fastqId is required")
 
     fastq_obj = get_fastq(fastq_id, includeS3Details=True)
 
-    satisfied_requirements, unsatisfied_requirements = (
-        check_fastq_against_requirements_list(
-            fastq_obj=fastq_obj,
-            requirements=requirements,
-            is_unarchiving_allowed=is_unarchiving_allowed
+    try:
+        satisfied_requirements, unsatisfied_requirements = (
+            check_fastq_against_requirements_list(
+                fastq_obj=fastq_obj,
+                requirements=requirements,
+                is_unarchiving_allowed=is_unarchiving_allowed,
+                has_active_readset_context=has_active_readset_context,
+            )
         )
-    )
+    except ContextNotEligibleError:
+        raise
 
     return {
         "fastqObj": fastq_obj,

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/__init__.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/__init__.py
@@ -4,8 +4,10 @@
 Fastq tools to be used by various lambdas as needed
 """
 from .utils.globals import REQUIREMENT
+from .utils.exceptions import ContextNotEligibleError
 from .utils.utils import (
     has_active_readset,
+    has_active_readset_in_context,
     has_qc,
     has_fingerprint,
     has_compression_metadata,
@@ -15,14 +17,20 @@ from .utils.utils import (
     run_fastq_unarchiving_job,
     check_fastq_against_requirements_list,
     check_fastq_list_against_requirements_list,
+    get_pipeline_cache_config,
+    is_allowed_context,
+    validate_has_active_readset_input,
 )
 
 
 __all__ = [
     # Requirements enum
     "REQUIREMENT",
+    # Exceptions
+    "ContextNotEligibleError",
     # All helpers
     "has_active_readset",
+    "has_active_readset_in_context",
     "has_qc",
     "has_fingerprint",
     "has_compression_metadata",
@@ -31,5 +39,8 @@ __all__ = [
     "run_fastq_job",
     "run_fastq_unarchiving_job",
     "check_fastq_against_requirements_list",
-    "check_fastq_list_against_requirements_list"
+    "check_fastq_list_against_requirements_list",
+    "get_pipeline_cache_config",
+    "is_allowed_context",
+    "validate_has_active_readset_input",
 ]

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/exceptions.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/exceptions.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Custom exceptions for the fastq sync tools layer.
+"""
+
+
+class ContextNotEligibleError(Exception):
+    """Raised when hasActiveReadSet context doesn't match allowed pipeline-cache bucket."""
+
+    def __init__(self, bucket: str, prefix: str):
+        self.bucket = bucket
+        self.prefix = prefix
+        super().__init__(
+            f"FASTQ is not available in the requested context "
+            f"(bucket={bucket}, prefix={prefix}) and the context "
+            f"is not eligible for automatic resolution."
+        )

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
@@ -242,7 +242,10 @@ def check_fastq_against_requirements_list(
                     raise ContextNotEligibleError(bucket, prefix)
                 # If allowed context but not in context, this is an archived/unavailable scenario
                 # but unarchiving is not allowed — raise the same ValueError as before
-                raise ValueError("Fastq object is archived but unarchiving is not specified in the fastq sync service")
+                raise ValueError(
+                    f"Fastq readset is not available in requested context "
+                    f"(bucket={bucket}, prefix={prefix}) and unarchiving is not allowed"
+                )
         else:
             # Original behavior: context-free check
             if not has_active_readset(fastq_obj):

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
@@ -5,27 +5,27 @@ Bunch of useful helper functions for lambdas in the fastq sync service
 """
 
 # Standard library imports
-from typing import Optional, List, Tuple
+import os
+from typing import Dict, Optional, List, Tuple, Union
 import logging
+from requests import HTTPError
 
 # Layer imports
 from orcabus_api_tools.fastq import (
     get_fastq_jobs,
     run_qc_stats,
     run_file_compression_stats,
-    run_ntsm, run_read_count_stats
+    run_ntsm, run_read_count_stats,
+    to_fastq_list_row
 )
-
 from orcabus_api_tools.fastq.models import (
     Job, JobType,
     Fastq
 )
-
 from orcabus_api_tools.fastq_unarchiving import (
     create_job as create_unarchiving_job,
     get_job_list_for_fastq
 )
-
 from orcabus_api_tools.fastq_unarchiving.models import (
     Job as UnarchivingJob,
 )
@@ -36,10 +36,12 @@ from .globals import (
     ACTIVE_STORAGE_CLASSES
 )
 
+from .exceptions import ContextNotEligibleError
+
 logger = logging.getLogger(__name__)
 
 
-def has_active_readset(fastq_obj: 'Fastq') -> bool:
+def has_active_readset(fastq_obj: Fastq) -> bool:
     if fastq_obj['readSet'] is None:
         return False
 
@@ -53,6 +55,33 @@ def has_active_readset(fastq_obj: 'Fastq') -> bool:
         if readset_object['storageClass'] not in ACTIVE_STORAGE_CLASSES:
             return False
 
+    return True
+
+
+def has_active_readset_in_context(fastq_obj: Fastq, bucket: str, prefix: str) -> bool:
+    """
+    Check if all non-null ReadSet objects for a FASTQ reside in the given bucket
+    with keys starting with the given prefix AND are in active storage.
+
+    Returns True if every non-null ReadSet object (r1, r2) has:
+    - storageClass in ACTIVE_STORAGE_CLASSES
+    - bucket equals the given bucket
+    - key starts with the given prefix
+
+    Returns False if readSet is None or no non-null ReadSet objects exist.
+    """
+    if fastq_obj['readSet'] is None:
+        return False
+
+    # Try running to_fastq_list_row with the bucket and prefix context
+    try:
+        to_fastq_list_row(
+            fastq_id=fastq_obj['id'],
+            bucket=bucket,
+            key_prefix=prefix,
+        )
+    except HTTPError:
+        return False
     return True
 
 
@@ -282,3 +311,126 @@ def check_fastq_list_against_requirements_list(
     unsatisfied_requirements = list(set(requirements) - satisfied_requirements)
 
     return list(satisfied_requirements), unsatisfied_requirements
+
+
+def get_pipeline_cache_config() -> Tuple[str, str]:
+    """
+    Read and validate PIPELINE_CACHE_BUCKET and PIPELINE_CACHE_PREFIX from environment.
+    Returns (pipeline_cache_bucket, byob_environment).
+    Raises RuntimeError if either is missing or empty.
+    """
+    pipeline_cache_bucket = os.environ.get("PIPELINE_CACHE_BUCKET", "")
+    byob_environment = os.environ.get("PIPELINE_CACHE_PREFIX", "")
+
+    if not pipeline_cache_bucket:
+        raise RuntimeError("Missing required environment variable: PIPELINE_CACHE_BUCKET")
+    if not byob_environment:
+        raise RuntimeError("Missing required environment variable: PIPELINE_CACHE_PREFIX")
+
+    return pipeline_cache_bucket, byob_environment
+
+
+def validate_has_active_readset_input(
+        has_active_readset_value: Union[bool, dict]
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """
+    Validate and normalize hasActiveReadSet input.
+
+    Args:
+        has_active_readset_value: Either a boolean or a dict with 'bucket' and 'prefix'.
+
+    Returns:
+        Tuple of (is_context_aware, bucket_or_none, prefix_or_none).
+        - For boolean True: (False, None, None) — context-free check
+        - For dict: (True, bucket, prefix) — context-aware check
+
+    Raises:
+        ValueError: If input is boolean False (should be excluded by caller),
+                    or if dict has missing/empty/invalid bucket or prefix,
+                    or if input is neither bool nor dict.
+    """
+    # Handle boolean input
+    if isinstance(has_active_readset_value, bool):
+        if has_active_readset_value:
+            return (False, None, None)
+        else:
+            raise ValueError(
+                "hasActiveReadSet value is False; "
+                "this requirement should be excluded from the requirements list"
+            )
+
+    # Handle dict input
+    if isinstance(has_active_readset_value, dict):
+        # Check 'bucket' key exists
+        if 'bucket' not in has_active_readset_value:
+            raise ValueError(
+                "hasActiveReadSet object is missing required attribute: 'bucket'"
+            )
+
+        # Check 'prefix' key exists
+        if 'prefix' not in has_active_readset_value:
+            raise ValueError(
+                "hasActiveReadSet object is missing required attribute: 'prefix'"
+            )
+
+        bucket = has_active_readset_value['bucket']
+        prefix = has_active_readset_value['prefix']
+
+        # Validate bucket is a string
+        if not isinstance(bucket, str):
+            raise ValueError("hasActiveReadSet 'bucket' must be a string")
+
+        # Validate prefix is a string
+        if not isinstance(prefix, str):
+            raise ValueError("hasActiveReadSet 'prefix' must be a string")
+
+        # Check bucket is non-empty after strip
+        if not bucket.strip():
+            raise ValueError(
+                "hasActiveReadSet 'bucket' must not be empty or whitespace-only"
+            )
+
+        # Check prefix is non-empty after strip
+        if not prefix.strip():
+            raise ValueError(
+                "hasActiveReadSet 'prefix' must not be empty or whitespace-only"
+            )
+
+        # Check bucket length (1-63)
+        if len(bucket) > 63:
+            raise ValueError(
+                f"hasActiveReadSet 'bucket' exceeds maximum length of 63 characters "
+                f"(got {len(bucket)})"
+            )
+
+        # Check prefix length (1-1024)
+        if len(prefix) > 1024:
+            raise ValueError(
+                f"hasActiveReadSet 'prefix' exceeds maximum length of 1024 characters "
+                f"(got {len(prefix)})"
+            )
+
+        return (True, bucket, prefix)
+
+    # Neither bool nor dict
+    raise ValueError(
+        f"hasActiveReadSet must be a boolean or an object with 'bucket' and 'prefix', "
+        f"got {type(has_active_readset_value).__name__}"
+    )
+
+
+def is_allowed_context(bucket: str, prefix: str) -> bool:
+    """
+    Check if the given bucket and prefix match the allowed pipeline-cache context.
+
+    Returns True if bucket equals PIPELINE_CACHE_BUCKET env var AND
+    prefix starts with '{PIPELINE_CACHE_PREFIX}'.
+
+    Uses get_pipeline_cache_config() internally to read environment variables.
+    """
+    pipeline_cache_bucket, pipeline_cache_prefix = get_pipeline_cache_config()
+
+    return (
+        bucket == pipeline_cache_bucket
+        and prefix.startswith(pipeline_cache_prefix)
+    )

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
@@ -60,15 +60,10 @@ def has_active_readset(fastq_obj: Fastq) -> bool:
 
 def has_active_readset_in_context(fastq_obj: Fastq, bucket: str, prefix: str) -> bool:
     """
-    Check if all non-null ReadSet objects for a FASTQ reside in the given bucket
-    with keys starting with the given prefix AND are in active storage.
+    Check whether the FASTQ readset is resolvable in the provided (bucket, prefix) context.
 
-    Returns True if every non-null ReadSet object (r1, r2) has:
-    - storageClass in ACTIVE_STORAGE_CLASSES
-    - bucket equals the given bucket
-    - key starts with the given prefix
-
-    Returns False if readSet is None or no non-null ReadSet objects exist.
+    This implementation delegates the validation to `orcabus_api_tools.fastq.to_fastq_list_row(...)`:
+    it returns True if that call succeeds, and False if it raises an HTTPError.
     """
     if fastq_obj['readSet'] is None:
         return False

--- a/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
+++ b/app/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
@@ -211,10 +211,16 @@ def run_fastq_unarchiving_job(fastq: Fastq) -> Optional[UnarchivingJob]:
 def check_fastq_against_requirements_list(
         fastq_obj: Fastq,
         requirements: List[REQUIREMENT],
-        is_unarchiving_allowed: bool = False
+        is_unarchiving_allowed: bool = False,
+        has_active_readset_context: Optional[Dict[str, str]] = None
 ) -> Tuple[List[REQUIREMENT], List[REQUIREMENT]]:
     """
-    Given a fastq list row and the requirements, split requirements into two lists, one that is satisfied and one that is not
+    Given a fastq list row and the requirements, split requirements into two lists, one that is satisfied and one that is not.
+
+    When has_active_readset_context is provided (dict with 'bucket' and 'prefix'), the hasActiveReadSet
+    requirement is evaluated context-aware: the readset must exist in the specified bucket/prefix.
+    If not in context and the context is not allowed, raises ContextNotEligibleError.
+    If not in context and the context IS allowed, reports as unsatisfied (downstream handles unarchiving).
     """
 
     satisfied_requirements = []
@@ -225,19 +231,45 @@ def check_fastq_against_requirements_list(
     if (
             not is_unarchiving_allowed
             and 'hasActiveReadSet' in requirements
-            and (not has_active_readset(fastq_obj))
             and fastq_obj['readSet'] is not None
     ):
-        raise ValueError("Fastq object is archived but unarchiving is not specified in the fastq sync service")
+        if has_active_readset_context is not None:
+            # Context-aware archived check
+            bucket = has_active_readset_context['bucket']
+            prefix = has_active_readset_context['prefix']
+            if not has_active_readset_in_context(fastq_obj, bucket, prefix):
+                if not is_allowed_context(bucket, prefix):
+                    raise ContextNotEligibleError(bucket, prefix)
+                # If allowed context but not in context, this is an archived/unavailable scenario
+                # but unarchiving is not allowed — raise the same ValueError as before
+                raise ValueError("Fastq object is archived but unarchiving is not specified in the fastq sync service")
+        else:
+            # Original behavior: context-free check
+            if not has_active_readset(fastq_obj):
+                raise ValueError("Fastq object is archived but unarchiving is not specified in the fastq sync service")
 
     # Just a large if else block to check the requirements
     for requirement_iter_ in requirements:
         # Check read set
         if requirement_iter_ == 'hasActiveReadSet':
-            if has_active_readset(fastq_obj):
-                satisfied_requirements.append(requirement_iter_)
+            if has_active_readset_context is not None:
+                # Context-aware evaluation
+                bucket = has_active_readset_context['bucket']
+                prefix = has_active_readset_context['prefix']
+                if has_active_readset_in_context(fastq_obj, bucket, prefix):
+                    satisfied_requirements.append(requirement_iter_)
+                else:
+                    # Not in context — check if context is allowed
+                    if not is_allowed_context(bucket, prefix):
+                        raise ContextNotEligibleError(bucket, prefix)
+                    # Allowed context but not in context: report as unsatisfied
+                    unsatisfied_requirements.append(requirement_iter_)
             else:
-                unsatisfied_requirements.append(requirement_iter_)
+                # Original context-free evaluation
+                if has_active_readset(fastq_obj):
+                    satisfied_requirements.append(requirement_iter_)
+                else:
+                    unsatisfied_requirements.append(requirement_iter_)
 
         # Check qc
         if requirement_iter_ == 'hasQc':
@@ -275,6 +307,7 @@ def check_fastq_list_against_requirements_list(
         fastq_list: List[Fastq],
         requirements: List[REQUIREMENT],
         is_unarchiving_allowed: bool = False,
+        has_active_readset_context: Optional[Dict[str, str]] = None,
 ) -> Tuple[List[REQUIREMENT], List[REQUIREMENT]]:
     """
     Given a list of fastqs and the requirements,
@@ -291,7 +324,8 @@ def check_fastq_list_against_requirements_list(
         satisfied_requirements_iter_, unsatisfied_requirements_iter_ = check_fastq_against_requirements_list(
             fastq_obj,
             requirements,
-            is_unarchiving_allowed
+            is_unarchiving_allowed,
+            has_active_readset_context=has_active_readset_context
         )
 
         # If there are no unsatisfied requirements, continue to the next fastq object

--- a/app/step-functions-templates/initialise_task_token_for_fastq_id_list_sfn_template.asl.json
+++ b/app/step-functions-templates/initialise_task_token_for_fastq_id_list_sfn_template.asl.json
@@ -10,6 +10,7 @@
         "fastqIdList": "{% $states.input.payload.fastqIdList %}",
         "requirements": "{% $states.input.payload.requirements %}",
         "isUnarchivingAllowed": "{% $states.input.payload.forceUnarchiving ? true : false %}",
+        "hasActiveReadSetContext": "{% $type($states.input.payload.requirements.hasActiveReadSet) = 'object' ? $states.input.payload.requirements.hasActiveReadSet : null %}",
         "callbackId": "{% $states.input.callbackId %}",
         "dynamoDbTableName": "${__dynamodb_table_name__}",
         "dynamoDbIdTypeKeys": {
@@ -64,7 +65,7 @@
       "Type": "Task",
       "Arguments": {
         "TaskToken": "{% $taskToken %}",
-        "Error": "FastqArchivedError",
+        "Error": "{% $parse($states.input.error.Cause).errorType ? $parse($states.input.error.Cause).errorType : 'FastqArchivedError' %}",
         "Cause": "{% $parse($states.input.error.Cause).errorMessage %}"
       },
       "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskFailure",
@@ -293,7 +294,8 @@
               "Input": {
                 "fastqId": "{% $states.input.fastqIdMapIter %}",
                 "requirements": "{% $states.input.requirementsListMapIter %}",
-                "isUnarchivingAllowed": "{% $isUnarchivingAllowed %}"
+                "isUnarchivingAllowed": "{% $isUnarchivingAllowed %}",
+                "hasActiveReadSetContext": "{% $hasActiveReadSetContext %}"
               }
             },
             "End": true

--- a/app/step-functions-templates/initialise_task_token_for_fastq_id_list_sfn_template.asl.json
+++ b/app/step-functions-templates/initialise_task_token_for_fastq_id_list_sfn_template.asl.json
@@ -131,7 +131,7 @@
                     "SS": "{% $fastqIdList %}"
                   },
                   "requirements_set": {
-                    "SS": "{% /* https://try.jsonata.org/slAM0Vym- */ [$keys($sift($requirements, function($v){$v = true}))] %}"
+                    "SS": "{% /* https://try.jsonata.org/slAM0Vym- */ [$keys($sift($requirements, function($v){$v}))] %}"
                   },
                   "expiresAt": {
                     "N": "{% ($round($toMillis($now()) / 1000) + (60 * 60 * 24 * 7)) ~> $string %}"

--- a/app/step-functions-templates/launch_fastq_list_row_requirements_sfn_template.asl.json
+++ b/app/step-functions-templates/launch_fastq_list_row_requirements_sfn_template.asl.json
@@ -8,7 +8,8 @@
       "Assign": {
         "fastqId": "{% $states.input.fastqId %}",
         "requirements": "{% $states.input.requirements %}",
-        "isUnarchivingAllowed": "{% $states.input.isUnarchivingAllowed ? $states.input.isUnarchivingAllowed : false %}"
+        "isUnarchivingAllowed": "{% $states.input.isUnarchivingAllowed ? $states.input.isUnarchivingAllowed : false %}",
+        "hasActiveReadSetContext": "{% $states.input.hasActiveReadSetContext ? $states.input.hasActiveReadSetContext : null %}"
       }
     },
     "Get fastq list row and remaining requirements": {
@@ -19,7 +20,8 @@
         "Payload": {
           "fastqId": "{% $fastqId %}",
           "requirements": "{% $requirements %}",
-          "isUnarchivingAllowed": "{% $isUnarchivingAllowed %}"
+          "isUnarchivingAllowed": "{% $isUnarchivingAllowed %}",
+          "hasActiveReadSetContext": "{% $hasActiveReadSetContext %}"
         }
       },
       "Retry": [
@@ -311,7 +313,9 @@
         "FunctionName": "${__launch_requirement_job_lambda_function_arn__}",
         "Payload": {
           "fastqId": "{% $fastqId %}",
-          "requirementType": "hasActiveReadSet"
+          "requirementType": "hasActiveReadSet",
+          "targetBucket": "{% $hasActiveReadSetContext ? $hasActiveReadSetContext.bucket : null %}",
+          "targetPrefix": "{% $hasActiveReadSetContext ? $hasActiveReadSetContext.prefix : null %}"
         }
       },
       "Retry": [

--- a/infrastructure/stage/config.ts
+++ b/infrastructure/stage/config.ts
@@ -5,6 +5,17 @@ import {
   FASTQ_SYNC_TASK_TOKEN_TABLE_NAME,
 } from './constants';
 import { EVENT_BUS_NAME } from '@orcabus/platform-cdk-constructs/shared-config/event-bridge';
+import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accounts';
+import { PIPELINE_CACHE_BUCKET } from '@orcabus/platform-cdk-constructs/shared-config/s3';
+
+/**
+ * Mapping from deployment stage to BYOB environment identifier.
+ */
+const PIPELINE_CACHE_PREFIX: Record<StageName, string> = {
+  BETA: 'byob-icav2/development/',
+  GAMMA: 'byob-icav2/staging/',
+  PROD: 'byob-icav2/production/',
+};
 
 export const getStatefulApplicationProps = (): StatefulApplicationConfig => {
   return {
@@ -19,7 +30,7 @@ export const getStatefulApplicationProps = (): StatefulApplicationConfig => {
   };
 };
 
-export const getStatelessApplicationProps = (): StatelessApplicationConfig => {
+export const getStatelessApplicationProps = (stage: StageName): StatelessApplicationConfig => {
   return {
     // Event Bus
     eventBusName: EVENT_BUS_NAME,
@@ -29,5 +40,9 @@ export const getStatelessApplicationProps = (): StatelessApplicationConfig => {
 
     // Sqs event sourcing
     sqsQueueName: DEFAULT_SQS_QUEUE_NAME,
+
+    // Pipeline cache configuration
+    pipelineCacheBucket: PIPELINE_CACHE_BUCKET[stage],
+    pipelineCachePrefix: PIPELINE_CACHE_PREFIX[stage],
   };
 };

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -22,4 +22,8 @@ export interface StatelessApplicationConfig {
 
   // Sqs stuff
   sqsQueueName: string;
+
+  // Pipeline cache configuration
+  pipelineCacheBucket: string;
+  pipelineCachePrefix: string;
 }

--- a/infrastructure/stage/lambdas/index.ts
+++ b/infrastructure/stage/lambdas/index.ts
@@ -88,6 +88,18 @@ function buildLambda(scope: Construct, props: LambdaProps): LambdaObject {
     );
   }
 
+  // Add pipeline cache environment variables for context-aware lambdas
+  if (
+    [
+      'checkFastqIdListAgainstRequirements',
+      'getFastqAndRemainingRequirements',
+      'launchRequirementJob',
+    ].includes(props.lambdaName)
+  ) {
+    lambdaFunction.addEnvironment('PIPELINE_CACHE_BUCKET', props.pipelineCacheBucket);
+    lambdaFunction.addEnvironment('PIPELINE_CACHE_PREFIX', props.pipelineCachePrefix);
+  }
+
   // Needs Callback Permissions
   if (lambdaRequirements.needsCallbackPermissions) {
     // Grant write permissions to allow the lambda to unlock durable executions

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -70,6 +70,8 @@ export interface BuildAllLambdaProps {
   fastqSyncLayer: LayerVersion;
   sqsQueue: IQueue;
   initialiseTaskTokenForFastqIdListSfnName: StepFunctionsName;
+  pipelineCacheBucket: string;
+  pipelineCachePrefix: string;
 }
 
 export interface LambdaProps extends BuildAllLambdaProps {

--- a/infrastructure/stage/stateless-application-stack.ts
+++ b/infrastructure/stage/stateless-application-stack.ts
@@ -42,6 +42,8 @@ export class StatelessApplicationStack extends cdk.Stack {
       fastqSyncLayer: fastqSyncToolsLayer,
       sqsQueue: sqsQueue,
       initialiseTaskTokenForFastqIdListSfnName: 'initialiseTaskTokenForFastqIdList',
+      pipelineCacheBucket: props.pipelineCacheBucket,
+      pipelineCachePrefix: props.pipelineCachePrefix,
     });
 
     // Build the state machines

--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -18,9 +18,9 @@ export class StatelessStack extends cdk.Stack {
       stack: StatelessApplicationStack,
       stackName: 'StatelessFastqSyncManager',
       stackConfig: {
-        beta: getStatelessApplicationProps(),
-        gamma: getStatelessApplicationProps(),
-        prod: getStatelessApplicationProps(),
+        beta: getStatelessApplicationProps('BETA'),
+        gamma: getStatelessApplicationProps('GAMMA'),
+        prod: getStatelessApplicationProps('PROD'),
       },
       pipelineName: 'StatelessFastqSyncManagerDeploymentPipeline',
       cdkSynthCmd: ['pnpm install --frozen-lockfile --ignore-scripts', 'pnpm cdk-stateless synth'],

--- a/test/stage.test.ts
+++ b/test/stage.test.ts
@@ -20,7 +20,7 @@ describe('cdk-nag-stateless-toolchain-stack', () => {
   const statelessApplicationStack = new StatelessApplicationStack(
     app,
     'StatelessApplicationStack',
-    getStatelessApplicationProps()
+    getStatelessApplicationProps('PROD')
   );
 
   Aspects.of(statelessApplicationStack).add(new AwsSolutionsChecks());


### PR DESCRIPTION
Extends the `hasActiveReadSet` requirement to validate FASTQ readsets against a specific S3 bucket and prefix, which is crucial for integrating with pipeline cache environments.

**Key changes include:**
*   **Schema Update:** Allows the `hasActiveReadSet` requirement to specify `bucket` and `prefix` within the event schema.
*   **Lambda Logic:** Updates `check_fastq_id_list_against_requirements` and `get_fastq_and_remaining_requirements` to parse and utilize the new context during validation.
*   **Shared Utilities:** Introduces `has_active_readset_in_context` for validating readset location, `ContextNotEligibleError` for specific context mismatches, and helpers for environment variable-based pipeline cache configuration.
*   **State Machine Propagation:** Modifies state machines to consistently pass the `hasActiveReadSetContext` throughout the workflow and enhances error handling to gracefully capture and report `ContextNotEligibleError`.
*   **Infrastructure:** Configures relevant lambdas with environment variables for the pipeline cache bucket and prefix, enabling them to identify and validate allowed contexts.